### PR TITLE
Repairing ontico page

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -8,6 +8,7 @@ module.exports = {
       'loremflickr.com',
       'baconmockup.com',
       'placebear.com',
+      'dl.airtable.com',
     ],
   },
 }

--- a/src/pages/ontico.js
+++ b/src/pages/ontico.js
@@ -14,14 +14,23 @@ import MentorsSearch from '../components/MentorsSearch'
 import MetaHeader from '../components/MetaHeader'
 import analytics from '../lib/analytics'
 import { useEffect } from 'react'
+import Link from 'next/link'
+import makeFilter from '../config/makeFilter'
+import { loadingSpecializations, loadingExperiences, loadingPrices } from '../datas/datas_loader'
 
 export async function getServerSideProps(context) {
   const allMentors = await getAllMentors({ onlyVisible: true })
   const pageMentors = allMentors.filter((mentor) => mentor.tags.includes('Сообщество Онтико'))
+  const specializations = await loadingSpecializations()
+  const prices = await loadingPrices()
+  const experiences = await loadingExperiences()
 
   return {
     props: {
       pageMentors,
+      specializations,
+      prices,
+      experiences,
     },
   }
 }
@@ -58,15 +67,15 @@ const galleryPhotos = [
 function Feature({ title, text, imageUrl }) {
   return (
     <div className="text-center p-4">
-      <Image className="inline w-40" src={imageUrl} />
+      <Image className="inline w-40" src={imageUrl} width={400} height={(400 / 1024) * 220} />
       <p>{text}</p>
     </div>
   )
 }
 
-export default function Ontico({ pageMentors }) {
+export default function Ontico({ pageMentors, specializations, prices, experiences }) {
   const [mentors, searchInput, hasMoreMentors, setSearchInput, showMoreMentors, appliedFilters] =
-    useMentors(pageMentors)
+    useMentors(pageMentors, makeFilter(specializations, prices, experiences))
 
   useEffect(() => {
     analytics.event('Visit Ontico Page')
@@ -96,14 +105,14 @@ export default function Ontico({ pageMentors }) {
 
           <p className="text-3xl lg:text-right font-light">уже 15 лет :)</p>
 
-          <a
+          <Link
             className="button bg-primary-900 mt-6"
             href={ontico_landing_url}
             target="_blank"
             rel="noreferrer"
           >
             Наши конференции
-          </a>
+          </Link>
         </div>
       </Section>
 
@@ -226,7 +235,13 @@ export default function Ontico({ pageMentors }) {
         </div>
 
         <div className="mb-8">
-          <MentorsFilters allowSponsors={false} appliedFilters={appliedFilters} />
+          <MentorsFilters
+            allowSponsors={false}
+            appliedFilters={appliedFilters}
+            specializations={specializations}
+            prices={prices}
+            experiences={experiences}
+          />
         </div>
 
         <MentorsList
@@ -240,14 +255,14 @@ export default function Ontico({ pageMentors }) {
         <Section.Title>Календарь конференций</Section.Title>
 
         <div className="text-center">
-          <a
+          <Link
             className="button bg-primary-900"
             target="_blank"
             href={ontico_landing_url}
             rel="noreferrer"
           >
             Все наши конференции
-          </a>
+          </Link>
         </div>
       </Section>
 

--- a/src/pages/ontico.js
+++ b/src/pages/ontico.js
@@ -67,7 +67,13 @@ const galleryPhotos = [
 function Feature({ title, text, imageUrl }) {
   return (
     <div className="text-center p-4">
-      <Image className="inline w-40" src={imageUrl} width={400} height={(400 / 1024) * 220} />
+      <Image
+        className="inline w-40"
+        src={imageUrl}
+        alt="ontico-logo"
+        width={400}
+        height={(400 / 1024) * 220}
+      />
       <p>{text}</p>
     </div>
   )
@@ -95,7 +101,7 @@ export default function Ontico({ pageMentors, specializations, prices, experienc
       <Section id="header">
         <div className="py-14 max-w-screen-lg mx-auto">
           <h1 className="-ml-3">
-            <Image src="/images/ontico.png" alt="Онтико" width={400} height={(400 / 1024) * 220} />
+            <Image src="/images/ontico.png" alt="Ontico" width={400} height={(400 / 1024) * 220} />
           </h1>
 
           <p className="text-3xl leading-relaxed">
@@ -121,6 +127,7 @@ export default function Ontico({ pageMentors, specializations, prices, experienc
           <div className="text-center">
             <Image
               src="ontico/19-09-23_16-19_0674_hcqqsy.jpg"
+              alt="ontico-conference-image"
               width={550}
               height={(1333 / 2000) * 550}
               loader={({ src, width, quality }) => {
@@ -185,6 +192,7 @@ export default function Ontico({ pageMentors, specializations, prices, experienc
             >
               <Image
                 src={photoUrl}
+                alt="ontico-random-photo"
                 width={300}
                 height={200}
                 loader={({ src, width, quality }) => {
@@ -212,6 +220,7 @@ export default function Ontico({ pageMentors, specializations, prices, experienc
           <div className="hidden lg:block">
             <Image
               src="ontico/21-05-17_17-03_0534_L_sj335b.jpg"
+              alt="ontico-mentor-photo"
               width={550}
               height={(1333 / 2000) * 550}
               loader={({ src, width, quality }) => {


### PR DESCRIPTION
Issue #27
----
_**пункт 5:** Страница ontico не работает - там надо разобраться с изображениями_
----

![Screenshot 2023-10-10 at 21-42-34 Конференции Онтико GetMentor – открытое сообщество IT-наставников](https://github.com/getmentor/getmentor-frontend/assets/93615236/246cde7c-ea26-4ef8-9a79-eec7f0098f73)

- [x] в [`next.config.js`](https://github.com/getmentor/getmentor-frontend/commit/7545eab620aef168981bd863ce5fcc70251c92bc) добавлен импорт из источника `'dl.airtable.com'`

- [x] Все `<a>` элементы заменены на [`<Link>`](https://nextjs.org/docs/pages/api-reference/components/link) чтобы избежать будущих проблем с гидратацией компонентов

- [x] Добавлена длина и ширина [логотипа](https://github.com/getmentor/getmentor-frontend/commit/1a309b07de37314e557f300e0fe3b760dba5f402#diff-3af5edc3ddb286fde5c28c4d91d29542e690f8baf99d30c84cd920c0a8cc6488R70) Онтико, из-за которой страница не загружалась
![Screenshot from 2023-10-10 21-23-43](https://github.com/getmentor/getmentor-frontend/assets/93615236/630c66e0-bc9a-4e5d-a241-f9a502c168f0)

- [x] В функцию [`getServerSideProps(context)`](https://github.com/getmentor/getmentor-frontend/commit/1a309b07de37314e557f300e0fe3b760dba5f402#diff-3af5edc3ddb286fde5c28c4d91d29542e690f8baf99d30c84cd920c0a8cc6488R21-R33) добавлены загрузчики специализаций, опыта и цен, из-за которых была ошибка `data is undefined`
![Screenshot from 2023-10-10 21-24-11](https://github.com/getmentor/getmentor-frontend/assets/93615236/0ccfca4d-bdf2-4c0b-b66d-0cc1c0583634)
![Screenshot from 2023-10-10 21-24-21](https://github.com/getmentor/getmentor-frontend/assets/93615236/3285d58c-90f8-49a2-85f4-3a27fb3664cd)
![Screenshot from 2023-10-10 21-24-35](https://github.com/getmentor/getmentor-frontend/assets/93615236/f1a38565-c17e-46eb-9c80-a3e584b55ee1)

- [x] Добавлены пропсы в компонент [`Ontico`](https://github.com/getmentor/getmentor-frontend/commit/1a309b07de37314e557f300e0fe3b760dba5f402#diff-3af5edc3ddb286fde5c28c4d91d29542e690f8baf99d30c84cd920c0a8cc6488R76-R78) и дополнен компонент [`<MentorsFilters />`](https://github.com/getmentor/getmentor-frontend/commit/1a309b07de37314e557f300e0fe3b760dba5f402#diff-3af5edc3ddb286fde5c28c4d91d29542e690f8baf99d30c84cd920c0a8cc6488R238-R244), чтобы в конце страницы правильно работала фильтрация по менторам

- [ ] На основном сайте и в нашем проекте сломались ссылки на 3 картинки в компонентах [`<Feature />`](https://github.com/getmentor/getmentor-frontend/commit/1a309b07de37314e557f300e0fe3b760dba5f402#diff-3af5edc3ddb286fde5c28c4d91d29542e690f8baf99d30c84cd920c0a8cc6488R158-R171), их не трогал
![Screenshot from 2023-10-10 22-03-48](https://github.com/getmentor/getmentor-frontend/assets/93615236/701a6767-f4ab-451c-9d44-bcd5026c43a2)

- [ ] На главной странице и на некоторых других страницах часто появляются ошибки гидратации, связанные с тегом `<a>`. Как я понял, это особенность next.js. Некоторые я починил у себя локально. В коммиты не добавлял.
![Screenshot from 2023-10-10 20-01-43](https://github.com/getmentor/getmentor-frontend/assets/93615236/66853677-810e-4c25-bc84-06e0d188e80b)
![Screenshot from 2023-10-10 20-27-17](https://github.com/getmentor/getmentor-frontend/assets/93615236/e24b2de5-b4ef-40a3-8332-a4f02e6a5b9f)
